### PR TITLE
Bump ink-dev dep to 1.0.0

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -54,7 +54,7 @@ jobs:
   build-contracts:
     runs-on: ubuntu-20.04
     env:
-      DOCKER_IMAGE: "public.ecr.aws/p6e8q1z1/ink-dev:0.2.0"
+      DOCKER_IMAGE: "public.ecr.aws/p6e8q1z1/ink-dev:1.0.0"
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3


### PR DESCRIPTION
`ink-dev:1.0.0` rocks support for stable [ink4 release](https://github.com/Cardinal-Cryptography/docker-ink-dev/blob/main/Dockerfile#L37).