### PR TITLE
Make deposit-id required for the withdrawal command

### DIFF
--- a/shielder/cli/src/config.rs
+++ b/shielder/cli/src/config.rs
@@ -115,7 +115,7 @@ pub struct DepositCmd {
 #[derive(Clone, Eq, PartialEq, Debug, Args)]
 pub struct WithdrawCmd {
     /// Which note should be spent, last created if none provided.
-    #[clap(long)]
+    #[clap(long, required_unless_present("interactive"))]
     pub deposit_id: Option<DepositId>,
 
     /// How many tokens should be withdrawn.


### PR DESCRIPTION
It used to blow up when `deposit-id` was not supplied and yet didn't inform the user about the necessary argument :)