### PR TITLE
Ink wrapper, CLI support for merge relation

### DIFF
--- a/shielder/README.md
+++ b/shielder/README.md
@@ -130,6 +130,39 @@ Note that you will still need to type in the seed of the withdrawer, not the rec
 
 You can now check if Hans' balance has been increased accordingly (we bet you 10 TZERO it has!).
 
+### Merging assets
+Merging assets allows you to combine two `deposit-id`s into one, preserving the value of the tokens.
+
+Starting from a fresh deployment, you can deposit funds for Damian, following the previously-outlined procedure:
+
+```bash
+./target/release/shielder-cli deposit 0 10 
+```
+
+While depositing a second batch of tokens for Damian, let us require a new deposit to be created:
+
+```bash
+./target/release/shielder-cli deposit 0 15 --require-new-deposit
+```
+
+Now, the assets will reflect the split between two `deposit-id`s:
+
+```
+assets=[Asset { token_id: 0, token_amount: 10, deposit_id: 0 }, Asset { token_id: 0, token_amount: 15, deposit_id: 1 }]
+```
+
+These two deposits can now be merged:
+```bash
+./target/release/shielder-cli merge 0 1
+```
+
+This results in the following state: 
+```
+assets=[Asset { token_id: 0, token_amount: 25, deposit_id: 0 }]
+```
+
+Mind that the merged deposit carries over the `deposit-id` of the first deposit provided to the merge command. Also, it is only possible to merge tokens deposited by one account. Trying to merge Damian's funds with Hans' will not work!
+
 ### Closing remarks
 
 If you made it this far: congrats! You've just completed your first foray into the land of privacy and zero-knowledge. Now you're ready to shield your tokens and make transfers through Shielder!

--- a/shielder/README.md
+++ b/shielder/README.md
@@ -145,7 +145,7 @@ While depositing a second batch of tokens for Damian, let us require a new depos
 ./target/release/shielder-cli deposit 0 15 --require-new-deposit
 ```
 
-Now, the assets will reflect the split between two `deposit-id`s:
+The assets will reflect the split between two `deposit-id`s:
 
 ```
 assets=[Asset { token_id: 0, token_amount: 10, deposit_id: 0 }, Asset { token_id: 0, token_amount: 15, deposit_id: 1 }]
@@ -161,7 +161,7 @@ This results in the following state:
 assets=[Asset { token_id: 0, token_amount: 25, deposit_id: 0 }]
 ```
 
-Mind that the merged deposit carries over the `deposit-id` of the first deposit provided to the merge command. Also, it is only possible to merge tokens deposited by one account. Trying to merge Damian's funds with Hans' will not work!
+Mind that the merged deposit carries over the `deposit-id` of the first deposit provided to the merge command.
 
 ### Closing remarks
 

--- a/shielder/cli/Cargo.lock
+++ b/shielder/cli/Cargo.lock
@@ -80,11 +80,12 @@ dependencies = [
 
 [[package]]
 name = "aleph_client"
-version = "2.15.0"
-source = "git+https://github.com/Cardinal-Cryptography/aleph-node/#92f84cb82c9f5c515a0063f41141143325c2133c"
+version = "2.13.0"
+source = "git+https://github.com/Cardinal-Cryptography/aleph-node.git?rev=r-10.0#5172d74220fb7a1ead675f7ed4105d87bf07c6c7"
 dependencies = [
  "anyhow",
  "async-trait",
+ "contract-metadata 2.1.0",
  "contract-transcode",
  "frame-support",
  "futures",
@@ -771,6 +772,19 @@ checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "contract-metadata"
+version = "2.0.0-beta.1"
+source = "git+https://github.com/paritytech/cargo-contract?rev=7ca8c365fc1e157cd52901c54949b2faf1cd8899#7ca8c365fc1e157cd52901c54949b2faf1cd8899"
+dependencies = [
+ "anyhow",
+ "impl-serde",
+ "semver 1.0.17",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "contract-metadata"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38765f12af802e382a9d8075dac1c3d28f9fbd7b5ee2776740ee8c9a8dd4f8c9"
@@ -785,14 +799,11 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73db6f39c07b43a0fb49410a2a4d8dbf6eaf1d8a646cb7430003e56e5b3522ed"
+version = "2.0.0-beta.1"
+source = "git+https://github.com/paritytech/cargo-contract?rev=7ca8c365fc1e157cd52901c54949b2faf1cd8899#7ca8c365fc1e157cd52901c54949b2faf1cd8899"
 dependencies = [
  "anyhow",
- "base58",
- "blake2 0.10.6",
- "contract-metadata",
+ "contract-metadata 2.0.0-beta.1",
  "escape8259",
  "hex",
  "indexmap",
@@ -802,11 +813,11 @@ dependencies = [
  "nom",
  "nom-supreme",
  "parity-scale-codec",
- "primitive-types",
  "scale-info",
  "serde",
  "serde_json",
- "thiserror",
+ "sp-core 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 
@@ -1892,6 +1903,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ink-wrapper-types"
+version = "0.1.0"
+source = "git+https://github.com/Cardinal-Cryptography/ink-wrapper/#ad0076e34a0f98558b2b7f0078e6b49c6b099bd5"
+dependencies = [
+ "aleph_client",
+ "anyhow",
+ "async-trait",
+ "ink_primitives",
+ "pallet-contracts-primitives",
+ "parity-scale-codec",
+ "subxt",
+]
+
+[[package]]
 name = "ink_allocator"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,8 +2923,8 @@ dependencies = [
 
 [[package]]
 name = "primitives"
-version = "0.6.0"
-source = "git+https://github.com/Cardinal-Cryptography/aleph-node/#92f84cb82c9f5c515a0063f41141143325c2133c"
+version = "0.5.5"
+source = "git+https://github.com/Cardinal-Cryptography/aleph-node.git?rev=r-10.0#5172d74220fb7a1ead675f7ed4105d87bf07c6c7"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3657,6 +3682,8 @@ dependencies = [
  "chacha20poly1305",
  "clap",
  "hex",
+ "ink-wrapper-types",
+ "ink_primitives",
  "inquire",
  "itertools",
  "liminal-ark-relations",

--- a/shielder/cli/Cargo.toml
+++ b/shielder/cli/Cargo.toml
@@ -38,8 +38,6 @@ ark-snark = { version = "^0.3.0", default-features = false }
 ark-std = { version = "^0.3.0", default-features = false }
 
 # todo: change this for versioned `aleph-client` right away after publishing it
-# aleph_client = { git = "https://github.com/Cardinal-Cryptography/aleph-node/" }
-# todo: change this to version without `rev`
 aleph_client = { git = "https://github.com/Cardinal-Cryptography/aleph-node.git", rev = "r-10.0" }
 liminal-ark-relations = "0.4.0"
 

--- a/shielder/cli/Cargo.toml
+++ b/shielder/cli/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 anyhow = "1.0"
 chacha20poly1305 = { version = "0.10.1", features = ["stream"] }
 clap = { version = "4.0", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
+scale = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full", "bit-vec"] }
 hex = "0.4.3"
 inquire = "0.5.2"
 itertools = "0.10.5"
@@ -38,8 +38,13 @@ ark-snark = { version = "^0.3.0", default-features = false }
 ark-std = { version = "^0.3.0", default-features = false }
 
 # todo: change this for versioned `aleph-client` right away after publishing it
-aleph_client = { git = "https://github.com/Cardinal-Cryptography/aleph-node/" }
+# aleph_client = { git = "https://github.com/Cardinal-Cryptography/aleph-node/" }
+# todo: change this to version without `rev`
+aleph_client = { git = "https://github.com/Cardinal-Cryptography/aleph-node.git", rev = "r-10.0" }
 liminal-ark-relations = "0.4.0"
+
+ink-wrapper-types = { git = "https://github.com/Cardinal-Cryptography/ink-wrapper/" }
+ink_primitives = "4.0.1"
 
 [dev-dependencies]
 serial_test = "1.0.0"

--- a/shielder/cli/README.md
+++ b/shielder/cli/README.md
@@ -1,78 +1,14 @@
 # shielder-cli
 Shielding assets with SNARKs from your CLI
 
-## Dev instructions
-1. Checkout `aleph-node` to `snarkeling` branch and build the node (`cargo build --release`).
-2. Comment out invocation to `verify_deposit()` in `Shielder` contract (`contracts/shielder/contract.rs`).
-3. Build docker image `docker build --tag aleph-node:snarkeling -f ./docker/Dockerfile .`
-
-## Run one-node `snarknode` chain
+## Run setup procedure 
+From the `shielder` directory run:
 
 ```bash
-./contracts/run_snarknode.sh
+./deploy/deploy.sh
 ```
 
-## Deploy Shielder and PSP22 token contracts
+This will run the node and set up shielding.
 
-```bash
-cd contracts
-./setup_shielding.sh -r false -n ws://127.0.0.1:9943
-```
-
-Script will register the token with the Shielder contract at id 0 as well as give it the allowance to spend up to total_supply of the token on behalf of Alice.
-
-## Interact with the Shielder contract
-
-Use `//Alice` as account seed and issue cli commands from the tool directory:
-
-```bash
-cd shielder-cli
-```
-
-### Set node RPC endpoint address
-
-```bash
-cargo run --release -- --seed //Alice set-node ws://127.0.0.1:9943
-```
-
-### Persist Shielder contract address instance
-
-```bash
-cargo run --release -- --seed //Alice set-contract-address <shielder-addrs>
-```
-
-### Register new PSP22 token contract with Shielder instance
-
-> This step is not required if you're working with local chain and had successfuly ran `./setup_shielding.sh`
-
-Before using Shielder contract to deposit/withdraw tokens, we need to first "register" the PSP22 token contract in our Shielder instance. Without this action, any transactions calling `deposit`/`withdraw` will fail.
-
-**NOTE:** Token IDs in Shielder instance have to be unique so if your transaction gets front-runned by someone else, trying to register under same `--token-id` you will have to retry the txn with a new token ID value.
-
-```bash
-cargo run --release -- --seed //Alice register-token --token-id 0 --token-address <PSP22_token_contract_address>
-```
-
-### Deposit a note
-
-> Assumes that you've successfuly completed previous step of registering a PSP token under `--token-id 0` and that you had approved allowance of that PSP token to the Shielder contract. Either manually or via `./setup_shielding.sh`.
-
-Deposits a note of 50 tokens of a PSP token registered with an id 0:
-
-```bash
-cargo run --release -- --seed //Alice deposit 0 100
-```
-
-### What notes do I have to spend?
-
-```bash
-cargo run --release -- --seed //Alice show-assets 0
-```
-
-### Withdraw a note
-
-Withdraws a note of 50 tokens of a PSP22 token registered under an id 0:
-
-```bash
-cargo run --release -- --seed //Alice withdraw  --deposit-id 0 --amount 50
-```
+## Usage
+The details are described in `shielder/README.md`.

--- a/shielder/cli/src/config.rs
+++ b/shielder/cli/src/config.rs
@@ -94,6 +94,10 @@ pub struct DepositCmd {
     /// Amount of the token to be shielded.
     pub amount: FrontendTokenAmount,
 
+    /// When provided, a new deposit is to be created even if a previous one exists.
+    #[clap(long, action)]
+    pub require_new_deposit: bool,
+
     /// Seed for submitting the transaction.
     ///
     /// If not provided, will be prompted.
@@ -160,11 +164,9 @@ pub struct WithdrawCmd {
 pub struct MergeCmd {
     /// First of the notes that should be spent. The merged amount will be stored under the leaf
     /// index of the first deposit. The second deposit will be deleted.
-    #[clap(long)]
     pub first_deposit_id: DepositId,
 
     /// Second of the notes that should be spent.
-    #[clap(long)]
     pub second_deposit_id: DepositId,
 
     /// Seed for submitting the transaction.

--- a/shielder/cli/src/config.rs
+++ b/shielder/cli/src/config.rs
@@ -66,6 +66,8 @@ pub enum ContractInteractionCommand {
     Deposit(DepositCmd),
     /// Unshield some tokens.
     Withdraw(WithdrawCmd),
+    /// Merge two tokens.
+    Merge(MergeCmd),
 }
 
 impl ContractInteractionCommand {
@@ -75,6 +77,9 @@ impl ContractInteractionCommand {
                 metadata_file.clone()
             }
             ContractInteractionCommand::Withdraw(WithdrawCmd { metadata_file, .. }) => {
+                metadata_file.clone()
+            }
+            ContractInteractionCommand::Merge(MergeCmd { metadata_file, .. }) => {
                 metadata_file.clone()
             }
         }
@@ -148,6 +153,34 @@ pub struct WithdrawCmd {
     ///
     /// If not found, command will fail - the tool won't generate it for you.
     #[clap(default_value = "withdraw.pk.bytes", value_parser = parsing::parse_path)]
+    pub proving_key_file: PathBuf,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Args)]
+pub struct MergeCmd {
+    /// First of the notes that should be spent. The merged amount will be stored under the leaf
+    /// index of the first deposit. The second deposit will be deleted.
+    #[clap(long)]
+    pub first_deposit_id: DepositId,
+
+    /// Second of the notes that should be spent.
+    #[clap(long)]
+    pub second_deposit_id: DepositId,
+
+    /// Seed for submitting the transaction.
+    ///
+    /// If not provided, will be prompted.
+    #[clap(long)]
+    pub caller_seed: Option<String>,
+
+    /// File with contract metadata.
+    #[clap(long, default_value = "shielder-metadata.json", value_parser = parsing::parse_path)]
+    pub metadata_file: PathBuf,
+
+    /// File with raw proving key bytes for the merging of deposits.
+    ///
+    /// If not found, command will fail - the tool won't generate it for you.
+    #[clap(default_value = "merge.pk.bytes", value_parser = parsing::parse_path)]
     pub proving_key_file: PathBuf,
 }
 

--- a/shielder/cli/src/contract.rs
+++ b/shielder/cli/src/contract.rs
@@ -17,11 +17,15 @@ use tracing::info;
 
 use crate::ink_contract::Instance;
 
+fn inkify_account_id(account_id: &AccountId) -> ink_primitives::AccountId {
+    let inner: [u8; 32] = *account_id.as_ref();
+    inner.into()
+}
+
 impl From<&ContractInstance> for Instance {
     fn from(contract: &ContractInstance) -> Self {
         let account_id = contract.address();
-        let inner: [u8; 32] = *account_id.as_ref();
-        let ink_account_id: ink_primitives::AccountId = inner.into();
+        let ink_account_id = inkify_account_id(account_id);
         ink_account_id.into()
     }
 }
@@ -78,8 +82,7 @@ impl Shielder {
         proof: &[u8],
     ) -> Result<u32> {
         let ink_contract: Instance = (&self.contract).into();
-        let inner: [u8; 32] = *recipient.as_ref();
-        let ink_recipient: ink_primitives::AccountId = inner.into();
+        let ink_recipient = inkify_account_id(recipient);
 
         let tx_info = ink_contract
             .withdraw(

--- a/shielder/cli/src/deposit.rs
+++ b/shielder/cli/src/deposit.rs
@@ -15,7 +15,7 @@ use crate::{
     generate_proof, DepositId, MERKLE_PATH_MAX_LEN,
 };
 
-pub async fn first_deposit(
+pub async fn new_deposit(
     token_id: FrontendTokenId,
     token_amount: FrontendTokenAmount,
     proving_key_file: &Path,

--- a/shielder/cli/src/ink_contract.rs
+++ b/shielder/cli/src/ink_contract.rs
@@ -1,0 +1,282 @@
+use scale::Encode as _;
+
+#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
+pub enum ShielderError {
+    InsufficientPermission(OwnableError),
+    TooManyNotes(),
+    UnknownMerkleRoot(),
+    NullifierAlreadyUsed(),
+    TooHighFee(),
+    ChainExtension(BabyLiminalError),
+    Psp22(PSP22Error),
+    InkEnv(String),
+    TokenIdAlreadyRegistered(),
+    TokenIdNotRegistered(),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
+pub enum OwnableError {
+    CallerIsNotOwner(),
+    NewOwnerIsZero(),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
+pub enum BabyLiminalError {
+    IdentifierAlreadyInUse(),
+    VerificationKeyTooLong(),
+    StoreKeyErrorUnknown(),
+    UnknownVerificationKeyIdentifier(),
+    DeserializingProofFailed(),
+    DeserializingPublicInputFailed(),
+    DeserializingVerificationKeyFailed(),
+    VerificationFailed(),
+    IncorrectProof(),
+    VerifyErrorUnknown(),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
+pub enum PSP22Error {
+    Custom(Vec<u8>),
+    InsufficientBalance(),
+    InsufficientAllowance(),
+    ZeroRecipientAddress(),
+    ZeroSenderAddress(),
+    SafeTransferCheckFailed(Vec<u8>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
+pub enum Relation {
+    Deposit(),
+    DepositAndMerge(),
+    Merge(),
+    Withdraw(),
+}
+
+pub struct Instance {
+    account_id: ink_primitives::AccountId,
+}
+
+impl From<ink_primitives::AccountId> for Instance {
+    fn from(account_id: ink_primitives::AccountId) -> Self {
+        Self { account_id }
+    }
+}
+
+impl Instance {
+    /// Instantiate the contract. Set the caller as the owner.
+    #[allow(dead_code)]
+    pub async fn new<TxInfo, E, C: ink_wrapper_types::SignedConnection<TxInfo, E>>(
+        conn: &C,
+        salt: Vec<u8>,
+        max_leaves: u32,
+    ) -> Result<Self, E> {
+        let data = {
+            let mut data = vec![155, 174, 157, 94];
+            max_leaves.encode_to(&mut data);
+            data
+        };
+        let code_hash = [
+            149, 184, 4, 182, 7, 123, 213, 168, 101, 221, 109, 139, 50, 45, 79, 143, 182, 54, 121,
+            91, 181, 8, 218, 161, 66, 102, 203, 137, 238, 115, 255, 180,
+        ];
+        let account_id = conn.instantiate(code_hash, salt, data).await?;
+        Ok(Self { account_id })
+    }
+
+    ///  Trigger deposit action (see ADR for detailed description).
+    #[allow(dead_code)]
+    pub async fn deposit<TxInfo, E, C: ink_wrapper_types::SignedConnection<TxInfo, E>>(
+        &self,
+        conn: &C,
+        token_id: u16,
+        value: u128,
+        note: [u64; 4],
+        proof: Vec<u8>,
+    ) -> Result<TxInfo, E> {
+        let data = {
+            let mut data = vec![0, 0, 0, 1];
+            token_id.encode_to(&mut data);
+            value.encode_to(&mut data);
+            note.encode_to(&mut data);
+            proof.encode_to(&mut data);
+            data
+        };
+        conn.exec(self.account_id, data).await
+    }
+
+    ///  Trigger withdraw action (see ADR for detailed description).
+    #[allow(dead_code)]
+    pub async fn withdraw<TxInfo, E, C: ink_wrapper_types::SignedConnection<TxInfo, E>>(
+        &self,
+        conn: &C,
+        token_id: u16,
+        value: u128,
+        recipient: ink_primitives::AccountId,
+        fee_for_caller: Option<u128>,
+        merkle_root: [u64; 4],
+        nullifier: [u64; 4],
+        new_note: [u64; 4],
+        proof: Vec<u8>,
+    ) -> Result<TxInfo, E> {
+        let data = {
+            let mut data = vec![0, 0, 0, 2];
+            token_id.encode_to(&mut data);
+            value.encode_to(&mut data);
+            recipient.encode_to(&mut data);
+            fee_for_caller.encode_to(&mut data);
+            merkle_root.encode_to(&mut data);
+            nullifier.encode_to(&mut data);
+            new_note.encode_to(&mut data);
+            proof.encode_to(&mut data);
+            data
+        };
+        conn.exec(self.account_id, data).await
+    }
+
+    ///  Read the current root of the Merkle tree with notes.
+    #[allow(dead_code)]
+    pub async fn current_merkle_root<E, C: ink_wrapper_types::Connection<E>>(
+        &self,
+        conn: &C,
+    ) -> Result<Result<[u64; 4], ink_primitives::LangError>, E> {
+        let data = vec![0, 0, 0, 3];
+        conn.read(self.account_id, data).await
+    }
+
+    ///  Retrieve the path from the leaf to the root. `None` if the leaf does not exist.
+    #[allow(dead_code)]
+    pub async fn merkle_path<E, C: ink_wrapper_types::Connection<E>>(
+        &self,
+        conn: &C,
+        leaf_idx: u32,
+    ) -> Result<Result<Option<Vec<[u64; 4]>>, ink_primitives::LangError>, E> {
+        let data = {
+            let mut data = vec![0, 0, 0, 4];
+            leaf_idx.encode_to(&mut data);
+            data
+        };
+        conn.read(self.account_id, data).await
+    }
+
+    ///  Check whether `nullifier` has been already used.
+    #[allow(dead_code)]
+    pub async fn contains_nullifier<E, C: ink_wrapper_types::Connection<E>>(
+        &self,
+        conn: &C,
+        nullifier: [u64; 4],
+    ) -> Result<Result<bool, ink_primitives::LangError>, E> {
+        let data = {
+            let mut data = vec![0, 0, 0, 5];
+            nullifier.encode_to(&mut data);
+            data
+        };
+        conn.read(self.account_id, data).await
+    }
+
+    ///  Register a verifying key for one of the `Relation`.
+    ///
+    ///  For owner use only.
+    #[allow(dead_code)]
+    pub async fn register_vk<TxInfo, E, C: ink_wrapper_types::SignedConnection<TxInfo, E>>(
+        &self,
+        conn: &C,
+        relation: Relation,
+        vk: Vec<u8>,
+    ) -> Result<TxInfo, E> {
+        let data = {
+            let mut data = vec![0, 0, 0, 8];
+            relation.encode_to(&mut data);
+            vk.encode_to(&mut data);
+            data
+        };
+        conn.exec(self.account_id, data).await
+    }
+
+    ///  Check if there is a token address registered at `token_id`.
+    #[allow(dead_code)]
+    pub async fn registered_token_address<E, C: ink_wrapper_types::Connection<E>>(
+        &self,
+        conn: &C,
+        token_id: u16,
+    ) -> Result<Result<Option<ink_primitives::AccountId>, ink_primitives::LangError>, E> {
+        let data = {
+            let mut data = vec![0, 0, 0, 9];
+            token_id.encode_to(&mut data);
+            data
+        };
+        conn.read(self.account_id, data).await
+    }
+
+    ///  Register a token contract (`token_address`) at `token_id`.
+    ///
+    ///  For owner use only.
+    #[allow(dead_code)]
+    pub async fn register_new_token<
+        TxInfo,
+        E,
+        C: ink_wrapper_types::SignedConnection<TxInfo, E>,
+    >(
+        &self,
+        conn: &C,
+        token_id: u16,
+        token_address: ink_primitives::AccountId,
+    ) -> Result<TxInfo, E> {
+        let data = {
+            let mut data = vec![0, 0, 0, 10];
+            token_id.encode_to(&mut data);
+            token_address.encode_to(&mut data);
+            data
+        };
+        conn.exec(self.account_id, data).await
+    }
+
+    ///  Trigger deposit and merge action (see ADR for detailed description).
+    #[allow(dead_code)]
+    pub async fn deposit_and_merge<TxInfo, E, C: ink_wrapper_types::SignedConnection<TxInfo, E>>(
+        &self,
+        conn: &C,
+        token_id: u16,
+        value: u128,
+        merkle_root: [u64; 4],
+        nullifier: [u64; 4],
+        note: [u64; 4],
+        proof: Vec<u8>,
+    ) -> Result<TxInfo, E> {
+        let data = {
+            let mut data = vec![0, 0, 0, 11];
+            token_id.encode_to(&mut data);
+            value.encode_to(&mut data);
+            merkle_root.encode_to(&mut data);
+            nullifier.encode_to(&mut data);
+            note.encode_to(&mut data);
+            proof.encode_to(&mut data);
+            data
+        };
+        conn.exec(self.account_id, data).await
+    }
+
+    ///  Trigger merge action to combine the value of two notes.
+    #[allow(dead_code)]
+    pub async fn merge<TxInfo, E, C: ink_wrapper_types::SignedConnection<TxInfo, E>>(
+        &self,
+        conn: &C,
+        token_id: u16,
+        merkle_root: [u64; 4],
+        first_nullifier: [u64; 4],
+        second_nullifier: [u64; 4],
+        note: [u64; 4],
+        proof: Vec<u8>,
+    ) -> Result<TxInfo, E> {
+        let data = {
+            let mut data = vec![0, 0, 0, 12];
+            token_id.encode_to(&mut data);
+            merkle_root.encode_to(&mut data);
+            first_nullifier.encode_to(&mut data);
+            second_nullifier.encode_to(&mut data);
+            note.encode_to(&mut data);
+            proof.encode_to(&mut data);
+            data
+        };
+        conn.exec(self.account_id, data).await
+    }
+}

--- a/shielder/cli/src/ink_contract.rs
+++ b/shielder/cli/src/ink_contract.rs
@@ -52,6 +52,7 @@ pub enum Relation {
     Withdraw(),
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct Instance {
     account_id: ink_primitives::AccountId,
 }
@@ -59,6 +60,12 @@ pub struct Instance {
 impl From<ink_primitives::AccountId> for Instance {
     fn from(account_id: ink_primitives::AccountId) -> Self {
         Self { account_id }
+    }
+}
+
+impl From<Instance> for ink_primitives::AccountId {
+    fn from(instance: Instance) -> Self {
+        instance.account_id
     }
 }
 

--- a/shielder/cli/src/ink_contract.rs
+++ b/shielder/cli/src/ink_contract.rs
@@ -1,5 +1,7 @@
 use scale::Encode as _;
 
+// This file was auto-generated with ink-wrapper (https://crates.io/crates/ink-wrapper).
+
 #[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
 pub enum ShielderError {
     InsufficientPermission(OwnableError),
@@ -71,7 +73,7 @@ impl From<Instance> for ink_primitives::AccountId {
 
 impl Instance {
     /// Instantiate the contract. Set the caller as the owner.
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::too_many_arguments)]
     pub async fn new<TxInfo, E, C: ink_wrapper_types::SignedConnection<TxInfo, E>>(
         conn: &C,
         salt: Vec<u8>,
@@ -91,7 +93,7 @@ impl Instance {
     }
 
     ///  Trigger deposit action (see ADR for detailed description).
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::too_many_arguments)]
     pub async fn deposit<TxInfo, E, C: ink_wrapper_types::SignedConnection<TxInfo, E>>(
         &self,
         conn: &C,
@@ -112,7 +114,7 @@ impl Instance {
     }
 
     ///  Trigger withdraw action (see ADR for detailed description).
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::too_many_arguments)]
     pub async fn withdraw<TxInfo, E, C: ink_wrapper_types::SignedConnection<TxInfo, E>>(
         &self,
         conn: &C,
@@ -141,7 +143,7 @@ impl Instance {
     }
 
     ///  Read the current root of the Merkle tree with notes.
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::too_many_arguments)]
     pub async fn current_merkle_root<E, C: ink_wrapper_types::Connection<E>>(
         &self,
         conn: &C,
@@ -151,7 +153,7 @@ impl Instance {
     }
 
     ///  Retrieve the path from the leaf to the root. `None` if the leaf does not exist.
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::too_many_arguments)]
     pub async fn merkle_path<E, C: ink_wrapper_types::Connection<E>>(
         &self,
         conn: &C,
@@ -166,7 +168,7 @@ impl Instance {
     }
 
     ///  Check whether `nullifier` has been already used.
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::too_many_arguments)]
     pub async fn contains_nullifier<E, C: ink_wrapper_types::Connection<E>>(
         &self,
         conn: &C,
@@ -183,7 +185,7 @@ impl Instance {
     ///  Register a verifying key for one of the `Relation`.
     ///
     ///  For owner use only.
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::too_many_arguments)]
     pub async fn register_vk<TxInfo, E, C: ink_wrapper_types::SignedConnection<TxInfo, E>>(
         &self,
         conn: &C,
@@ -200,7 +202,7 @@ impl Instance {
     }
 
     ///  Check if there is a token address registered at `token_id`.
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::too_many_arguments)]
     pub async fn registered_token_address<E, C: ink_wrapper_types::Connection<E>>(
         &self,
         conn: &C,
@@ -217,7 +219,7 @@ impl Instance {
     ///  Register a token contract (`token_address`) at `token_id`.
     ///
     ///  For owner use only.
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::too_many_arguments)]
     pub async fn register_new_token<
         TxInfo,
         E,
@@ -238,7 +240,7 @@ impl Instance {
     }
 
     ///  Trigger deposit and merge action (see ADR for detailed description).
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::too_many_arguments)]
     pub async fn deposit_and_merge<TxInfo, E, C: ink_wrapper_types::SignedConnection<TxInfo, E>>(
         &self,
         conn: &C,
@@ -263,7 +265,7 @@ impl Instance {
     }
 
     ///  Trigger merge action to combine the value of two notes.
-    #[allow(dead_code)]
+    #[allow(dead_code, clippy::too_many_arguments)]
     pub async fn merge<TxInfo, E, C: ink_wrapper_types::SignedConnection<TxInfo, E>>(
         &self,
         conn: &C,

--- a/shielder/cli/src/lib.rs
+++ b/shielder/cli/src/lib.rs
@@ -17,6 +17,7 @@ pub const MERKLE_PATH_MAX_LEN: u8 = 16;
 pub mod app_state;
 pub mod contract;
 pub mod deposit;
+pub mod ink_contract;
 pub mod merge;
 pub mod withdraw;
 

--- a/shielder/cli/src/main.rs
+++ b/shielder/cli/src/main.rs
@@ -138,6 +138,7 @@ async fn do_deposit(
         token_id,
         amount,
         caller_seed,
+        require_new_deposit,
         ..
     } = cmd;
 
@@ -150,8 +151,9 @@ async fn do_deposit(
     let connection = SignedConnection::from_connection(connection, keypair_from_string(&seed));
 
     let old_deposit = app_state.get_last_deposit(token_id);
-    match old_deposit {
-        Some(old_deposit) => {
+
+    match (old_deposit, require_new_deposit) {
+        (Some(old_deposit), false) => {
             let _ = deposit_and_merge(
                 old_deposit,
                 amount,
@@ -163,8 +165,8 @@ async fn do_deposit(
             .await?;
             Ok(())
         }
-        None => {
-            let _ = first_deposit(
+        (_, _) => {
+            let _ = new_deposit(
                 token_id,
                 amount,
                 &cmd.deposit_key_file,

--- a/shielder/cli/src/main.rs
+++ b/shielder/cli/src/main.rs
@@ -209,6 +209,19 @@ async fn do_merge(
         .get_deposit_by_id(second_deposit_id)
         .ok_or(anyhow!("Cannot match second deposit id to actual deposit!"))?;
 
+    anyhow::ensure!(
+        first_deposit != second_deposit,
+        "Cannot merge a deposit with itself!"
+    );
+
+    let first_token_id = first_deposit.token_id;
+    let second_token_id = second_deposit.token_id;
+
+    anyhow::ensure!(
+        first_token_id == second_token_id,
+        "Cannot merge deposits with different token ids!"
+    );
+
     merge(
         first_deposit,
         second_deposit,

--- a/shielder/cli/tests/utils/mod.rs
+++ b/shielder/cli/tests/utils/mod.rs
@@ -49,7 +49,7 @@ impl User {
         token_amount: FrontendTokenAmount,
         shielder: &ShielderWrapper,
     ) -> Result<DepositId> {
-        let deposit_id = deposit::first_deposit(
+        let deposit_id = deposit::new_deposit(
             token_id,
             token_amount,
             &shielder.deposit_pk_file,

--- a/shielder/deploy/deploy.sh
+++ b/shielder/deploy/deploy.sh
@@ -64,6 +64,18 @@ prepare_fs() {
   log_progress "✅ Directories are set up"
 }
 
+install_ink_wrapper() {
+  cargo install --git https://github.com/Cardinal-Cryptography/ink-wrapper ink-wrapper
+}
+
+prepare_ink_types() {
+  # ensure that we are in shielder/cli folder
+  cd "${SCRIPT_DIR}"/../cli/
+  ink-wrapper -m shielder-metadata.json | rustfmt --edition 2021 > src/ink_contract.rs
+
+  log_progress "✅ Ink types were generated"
+}
+
 generate_chainspec() {
   CHAINSPEC_ARGS="\
     --base-path /data \
@@ -283,6 +295,10 @@ deploy() {
   # build contracts
   build
   move_build_artifacts
+
+  # generate ink types based on current contract metadata
+  install_ink_wrapper
+  prepare_ink_types
 
   prefund_users
 


### PR DESCRIPTION
Adds CLI support for the merge relation. Changes the way CLI is handled to use `ink!` types generated by the `ink-wrapper`. Adds changes to the deployment procedure to generate `ink!` types based on the current version of the contract metadata file.