### PR TITLE
Relayer fees

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shielder/PSP22"]
-	path = shielder/PSP22
-	url = https://github.com/Cardinal-Cryptography/PSP22.git

--- a/shielder/Makefile
+++ b/shielder/Makefile
@@ -26,19 +26,13 @@ check-drink-tests: ## Run cargo checks on drink tests.
 .PHONY: check
 check: check-contract check-mocked-zk check-drink-tests ## Run cargo checks
 
-.PHONY: build-psp22
-build-psp22: ## Builds psp22 contracts.
-	@echo "Building psp22 contract" ; \
-	git submodule update --init ; \
-	cargo contract build --quiet --manifest-path PSP22/Cargo.toml --features "contract" --release ; \
-
 .PHONY: build-shielder
 build-shielder: ## Builds shielder contracts.
 	@echo "Building shielder contract" ; \
 	cargo contract build --quiet --manifest-path contract/Cargo.toml --release ; \
 
 .PHONY: setup-tests
-setup-tests: build-psp22 build-shielder ## Builds contracts and generates wrappers.
+setup-tests: build-shielder ## Builds contracts and generates wrappers.
 
 .PHONY: shielder-unit-tests
 shielder-unit-tests: ## Runs unit tests for contract.

--- a/shielder/drink_tests/Cargo.lock
+++ b/shielder/drink_tests/Cargo.lock
@@ -1370,6 +1370,7 @@ dependencies = [
  "anyhow",
  "drink",
  "mocked_zk",
+ "psp22",
  "rand",
  "shielder-contract",
 ]
@@ -3487,6 +3488,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "psp22"
+version = "0.3.0"
+source = "git+https://github.com/Cardinal-Cryptography/PSP22.git?rev=676768b#676768b226d1460be95aff12cf35b3dcc84c7952"
+dependencies = [
+ "ink",
 ]
 
 [[package]]

--- a/shielder/drink_tests/Cargo.toml
+++ b/shielder/drink_tests/Cargo.toml
@@ -14,3 +14,4 @@ rand = { version = "0.8.5", default-features = false }
 anyhow = { version = "1.0.79", default-features = false }
 mocked_zk = { path = "../mocked_zk", default-features = false }
 shielder-contract = { path = "../contract", default-features = false, features = ["ink-as-dependency"] }
+psp22 = { git = "https://github.com/Cardinal-Cryptography/PSP22.git", rev = "676768b", default-features = false, features = ["ink-as-dependency", "contract"] }

--- a/shielder/drink_tests/src/utils/chain.rs
+++ b/shielder/drink_tests/src/utils/chain.rs
@@ -26,3 +26,9 @@ pub fn init_bob(session: &mut Session<MinimalSandbox>) -> Result<AccountId32> {
     init_acc_with_balance(session, &res)?;
     Ok(res)
 }
+
+pub fn init_relayer(session: &mut Session<MinimalSandbox>) -> Result<AccountId32> {
+    let res = AccountId32::new([4u8; 32]);
+    init_acc_with_balance(session, &res)?;
+    Ok(res)
+}

--- a/shielder/drink_tests/src/utils/ops.rs
+++ b/shielder/drink_tests/src/utils/ops.rs
@@ -43,3 +43,49 @@ pub fn withdraw_op(
         },
     }
 }
+
+pub fn deposit_op_relayer(
+    psp22_address: &AccountId32,
+    user: &AccountId32,
+    amount: u128,
+    azero_address: &AccountId32,
+    relayer: &AccountId32,
+    fee: u128,
+) -> UpdateOperation {
+    UpdateOperation {
+        op_pub: OpPub::DepositRelayer {
+            amount,
+            token: Scalar::from_bytes(*((*psp22_address).as_ref())),
+            user: Scalar::from_bytes(*((*user).as_ref())),
+            fee,
+            fee_token: Scalar::from_bytes(*((*azero_address).as_ref())),
+            relayer: Scalar::from_bytes(*((*relayer).as_ref())),
+        },
+        op_priv: OpPriv {
+            user: Scalar::from_bytes(*((*user).as_ref())),
+        },
+    }
+}
+
+pub fn withdraw_op_relayer(
+    psp22_address: &AccountId32,
+    user: &AccountId32,
+    amount: u128,
+    azero_address: &AccountId32,
+    relayer: &AccountId32,
+    fee: u128,
+) -> UpdateOperation {
+    UpdateOperation {
+        op_pub: OpPub::WithdrawRelayer {
+            amount,
+            token: Scalar::from_bytes(*((*psp22_address).as_ref())),
+            user: Scalar::from_bytes(*((*user).as_ref())),
+            fee,
+            fee_token: Scalar::from_bytes(*((*azero_address).as_ref())),
+            relayer: Scalar::from_bytes(*((*relayer).as_ref())),
+        },
+        op_priv: OpPriv {
+            user: Scalar::from_bytes(*((*user).as_ref())),
+        },
+    }
+}

--- a/shielder/drink_tests/src/utils/psp22.rs
+++ b/shielder/drink_tests/src/utils/psp22.rs
@@ -26,6 +26,26 @@ pub fn deploy_test_token(
     Ok(res)
 }
 
+pub fn deploy_azero_test_token(
+    session: &mut Session<MinimalSandbox>,
+    supply: u128,
+) -> Result<AccountId32> {
+    let psp22_bundle = BundleProvider::Psp22.bundle()?;
+    let res = session.deploy_bundle(
+        psp22_bundle,
+        "new",
+        &[
+            format!("{}", supply).as_str(),
+            "Some(\"AZERO\")",
+            "Some(\"AZERO\")",
+            "9",
+        ],
+        NO_SALT,
+        NO_ENDOWMENT,
+    )?;
+    Ok(res)
+}
+
 pub fn get_psp22_balance(
     session: &mut Session<MinimalSandbox>,
     token: &AccountId32,

--- a/shielder/drink_tests/src/utils/psp22.rs
+++ b/shielder/drink_tests/src/utils/psp22.rs
@@ -1,7 +1,8 @@
+use crate::tests::BundleProvider;
 use anyhow::Result;
 use drink::{
     minimal::MinimalSandbox,
-    session::{bundle::ContractBundle, Session, NO_ENDOWMENT, NO_SALT},
+    session::{Session, NO_ENDOWMENT, NO_SALT},
     AccountId32,
 };
 
@@ -9,8 +10,7 @@ pub fn deploy_test_token(
     session: &mut Session<MinimalSandbox>,
     supply: u128,
 ) -> Result<AccountId32> {
-    let psp22_bundle =
-        ContractBundle::load(std::path::Path::new("../PSP22/target/ink/psp22.contract"))?;
+    let psp22_bundle = BundleProvider::Psp22.bundle()?;
     let res = session.deploy_bundle(
         psp22_bundle,
         "new",

--- a/shielder/drink_tests/src/utils/shielder.rs
+++ b/shielder/drink_tests/src/utils/shielder.rs
@@ -25,11 +25,13 @@ pub struct ShielderUserEnv {
 
 pub fn deploy_shielder(
     session: &mut Session<MinimalSandbox>,
-    token: &AccountId32,
+    allowed_tokens: Vec<AccountId32>,
 ) -> Result<AccountId32> {
     let shielder_bundle = BundleProvider::ShielderContract.bundle()?;
     let mut tokens: [Scalar; TOKENS_NUMBER] = [0_u128.into(); TOKENS_NUMBER];
-    tokens[0] = Scalar::from_bytes(*((*token).as_ref()));
+    for (i, token) in allowed_tokens.iter().enumerate() {
+        tokens[i] = Scalar::from_bytes(*((*token).as_ref()));
+    }
     let res = session.deploy_bundle(
         shielder_bundle,
         "new",
@@ -43,11 +45,13 @@ pub fn deploy_shielder(
 pub fn create_shielder_account(
     session: &mut Session<MinimalSandbox>,
     shielder_address: &AccountId32,
-    token: &AccountId32,
+    allowed_tokens: Vec<AccountId32>,
     nullifier: Scalar,
 ) -> Result<ShielderUserEnv> {
     let mut tokens: [Scalar; TOKENS_NUMBER] = [0_u128.into(); TOKENS_NUMBER];
-    tokens[0] = Scalar::from_bytes(*((*token).as_ref()));
+    for (i, token) in allowed_tokens.iter().enumerate() {
+        tokens[i] = Scalar::from_bytes(*((*token).as_ref()));
+    }
 
     let acc = Account::new(tokens);
 

--- a/shielder/mocked_zk/src/ops.rs
+++ b/shielder/mocked_zk/src/ops.rs
@@ -22,6 +22,36 @@ pub enum OpPub {
         /// User address, to who the tokens are transferred
         user: Scalar,
     },
+    /// Deposit PSP-22 token through relayer
+    DepositRelayer {
+        /// amount of deposit
+        amount: u128,
+        /// PSP-22 token address
+        token: Scalar,
+        /// User address, from whom tokens are transferred
+        user: Scalar,
+        /// Fee amount for relayer
+        fee: u128,
+        /// PSP-22 token address
+        fee_token: Scalar,
+        /// Relayer address, from whom the transaction is initiated
+        relayer: Scalar,
+    },
+    /// Withdraw PSP-22 token
+    WithdrawRelayer {
+        /// amount of withdrawal
+        amount: u128,
+        /// PSP-22 token address
+        token: Scalar,
+        /// User address, to who the tokens are transferred
+        user: Scalar,
+        /// Fee amount for relayer
+        fee: u128,
+        /// PSP-22 token address
+        fee_token: Scalar,
+        /// Relayer address, from whom the transaction is initiated
+        relayer: Scalar,
+    },
 }
 
 /// empty private operation
@@ -53,6 +83,16 @@ impl Operation {
                 }
             }
             OpPub::Withdraw { user, .. } => {
+                if user != op_priv.user {
+                    return Err(ZkpError::OperationCombineError);
+                }
+            }
+            OpPub::DepositRelayer { user, .. } => {
+                if user != op_priv.user {
+                    return Err(ZkpError::OperationCombineError);
+                }
+            }
+            OpPub::WithdrawRelayer { user, .. } => {
                 if user != op_priv.user {
                     return Err(ZkpError::OperationCombineError);
                 }


### PR DESCRIPTION
introduced relayer logic by adding two public operations:
`DepositRelayer`, `WithdrawRelayer`
both operations mirror `Deposit` and `Relayer` respectively, but with three additional fields:
- `fee: u128` - amount of fee for relayer
- `fee_token: Scalar` - fee payment token
- `relayer: Scalar` - relayer address